### PR TITLE
Send slack messages as dogscaler

### DIFF
--- a/lib/dogscaler/slack.rb
+++ b/lib/dogscaler/slack.rb
@@ -12,7 +12,7 @@ module Dogscaler
     end
 
     def send_message(message)
-      @client.chat_postMessage(:channel => @channel, :text => message, :as_user => true)
+      @client.chat_postMessage(:channel => @channel, :text => message)
     end
 
   end


### PR DESCRIPTION
The slack client sends it's messages as user who installed the app if
:as_user => true is supplied to chat_postMessage method. This changes it
to false, so that user dogscaler is used as sender.